### PR TITLE
ADD: Format conv. part to xradar-basics

### DIFF
--- a/notebooks/xradar-pyart/xradar-basics.ipynb
+++ b/notebooks/xradar-pyart/xradar-basics.ipynb
@@ -381,6 +381,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Format Conversion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cf/Radial1 ⇋ Cf/Radial2  \n",
+    "By default, all formats load into the Cf/Radial2 structure in the *xradar* model. This allows you to transform any data format (HPL, GAMIC, ODIM, Sigmet) into the Cf/Radial1 format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = dt.xradar.to_cfradial1()\n",
+    "display(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_dt = ds.xradar.to_cfradial2()\n",
+    "display(new_dt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Xradar integration\n",
     "\n",
     "### Py-Art\n",
@@ -524,7 +559,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "xradar_latest",
    "language": "python",
    "name": "python3"
   },
@@ -538,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.9"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
Proposing to include`.xradar.to_cf1()` and `.xradar.to_cf2()` accessors in the basics one.